### PR TITLE
add Explorer-for-Linux (xbodwf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Restores: The Win11 File Explorer interface (including the classic 'Not Respondi
 - Supported languages: zh-CN
 - Intro video: https://www.bilibili.com/video/BV1ZWgV68EtU
 
+### [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) [Practical]
+
+Intro: A Windows 11 style file manager for Linux, built with Electron + Vue and WinUI-style web components.
+
+Restores: The Win11 File Explorer experience (Fluent/WinUI look and feel).
+
+- License: GPL-3.0
+- Authors: [xbodwf](https://github.com/xbodwf)
+- Primary language: zh-CN
+- Supported languages: zh-CN
+- Intro video: (pending)
+
 ### [mmclinux](https://gitee.com/windowsuninstaller/mmclinux) [Practical]
 
 Intro: A cross-platform tool mimicking the Windows Management Console, built with tkinter.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,18 @@
 - 支持语言：zh-CN
 - 介绍视频：https://www.bilibili.com/video/BV1ZWgV68EtU
 
+### [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) [实用]
+
+介绍：基于 Electron + Vue 与 WinUI 风格 Web 组件构建的 Win11 风格 Linux 文件管理器。
+
+还原的部分：Win11 资源管理器的界面与使用体验（Fluent/WinUI 视觉风格）。
+
+- 许可证：GPL-3.0
+- 作者：[xbodwf](https://github.com/xbodwf)
+- 主要语言：zh-CN
+- 支持语言：zh-CN
+- 介绍视频：（待补充）
+
 ### [mmclinux](https://gitee.com/windowsuninstaller/mmclinux) [实用]
 
 介绍：仿 Windows 管理控制台的跨平台工具，基于 tkinter 实现。

--- a/project-datas/2gui/explorer-for-linux-xbodwf/en-US.json
+++ b/project-datas/2gui/explorer-for-linux-xbodwf/en-US.json
@@ -1,0 +1,19 @@
+{
+  "name": "Explorer-for-Linux (xbodwf)",
+  "intro": "A Windows 11 style file manager for Linux, built with Electron + Vue and WinUI-style web components.",
+  "restores": "The Win11 File Explorer experience (Fluent/WinUI look and feel).",
+  "license": "GPL-3.0",
+  "video": "",
+  "url": "https://github.com/xbodwf/explorer-for-linux",
+  "authors": [
+    {
+      "name": "xbodwf",
+      "url": "https://github.com/xbodwf"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN"
+  ],
+  "intent": "practical"
+}

--- a/project-datas/2gui/explorer-for-linux-xbodwf/zh-CN.json
+++ b/project-datas/2gui/explorer-for-linux-xbodwf/zh-CN.json
@@ -1,0 +1,19 @@
+{
+  "name": "Explorer-for-Linux (xbodwf)",
+  "intro": "基于 Electron + Vue 与 WinUI 风格 Web 组件构建的 Win11 风格 Linux 文件管理器。",
+  "restores": "Win11 资源管理器的界面与使用体验（Fluent/WinUI 视觉风格）。",
+  "license": "GPL-3.0",
+  "video": "",
+  "url": "https://github.com/xbodwf/explorer-for-linux",
+  "authors": [
+    {
+      "name": "xbodwf",
+      "url": "https://github.com/xbodwf"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN"
+  ],
+  "intent": "practical"
+}


### PR DESCRIPTION
Adds [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) — a Windows 11 style file manager for Linux built with Electron + Vue and WinUI-style web components (contains code from [WinUIonWeb](https://github.com/Furry-Xiyi/WinUIonWeb), both GPL-3.0).

Note: distinct from the existing macOS-Terminal/Explorer-for-Linux entry. Data files added under `project-datas/2gui/explorer-for-linux-xbodwf` and both READMEs updated to match the generated format (no local Python to run `main.py generate`).