### PR TITLE
add Explorer-for-Linux (xbodwf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,4 +381,4 @@ Create the Pull Request; it merges once all Actions pass.
 [MIT](LICENSE) © 2026 windowix
 
 
-*Generated at: 2026-08-16 00:40 UTC*
+*Generated at: 2026-08-16 09:56 UTC*

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Restores: The Win11 File Explorer interface (including the classic 'Not Respondi
 - Supported languages: zh-CN
 - Intro video: https://www.bilibili.com/video/BV1ZWgV68EtU
 
+### [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) [Practical]
+
+Intro: A Windows 11 style file manager for Linux, built with Electron + Vue and WinUI-style web components.
+
+Restores: The Win11 File Explorer experience (Fluent/WinUI look and feel).
+
+- License: GPL-3.0
+- Authors: [xbodwf](https://github.com/xbodwf)
+- Primary language: zh-CN
+- Supported languages: zh-CN
+- Intro video: (pending)
+
 ### [mmclinux](https://gitee.com/windowsuninstaller/mmclinux) [Practical]
 
 Intro: A cross-platform tool mimicking the Windows Management Console, built with tkinter.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,18 @@
 - 支持语言：zh-CN
 - 介绍视频：https://www.bilibili.com/video/BV1ZWgV68EtU
 
+### [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) [实用]
+
+介绍：基于 Electron + Vue 与 WinUI 风格 Web 组件构建的 Win11 风格 Linux 文件管理器。
+
+还原的部分：Win11 资源管理器的界面与使用体验（Fluent/WinUI 视觉风格）。
+
+- 许可证：GPL-3.0
+- 作者：[xbodwf](https://github.com/xbodwf)
+- 主要语言：zh-CN
+- 支持语言：zh-CN
+- 介绍视频：（待补充）
+
 ### [mmclinux](https://gitee.com/windowsuninstaller/mmclinux) [实用]
 
 介绍：仿 Windows 管理控制台的跨平台工具，基于 tkinter 实现。

--- a/project-datas/2gui/explorer-for-linux-xbodwf/en-US.json
+++ b/project-datas/2gui/explorer-for-linux-xbodwf/en-US.json
@@ -1,0 +1,19 @@
+{
+  "name": "Explorer-for-Linux (xbodwf)",
+  "intro": "A Windows 11 style file manager for Linux, built with Electron + Vue and WinUI-style web components.",
+  "restores": "The Win11 File Explorer experience (Fluent/WinUI look and feel).",
+  "license": "GPL-3.0",
+  "video": "",
+  "url": "https://github.com/xbodwf/explorer-for-linux",
+  "authors": [
+    {
+      "name": "xbodwf",
+      "url": "https://github.com/xbodwf"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN"
+  ],
+  "intent": "practical"
+}

--- a/project-datas/2gui/explorer-for-linux-xbodwf/zh-CN.json
+++ b/project-datas/2gui/explorer-for-linux-xbodwf/zh-CN.json
@@ -1,0 +1,19 @@
+{
+  "name": "Explorer-for-Linux (xbodwf)",
+  "intro": "基于 Electron + Vue 与 WinUI 风格 Web 组件构建的 Win11 风格 Linux 文件管理器。",
+  "restores": "Win11 资源管理器的界面与使用体验（Fluent/WinUI 视觉风格）。",
+  "license": "GPL-3.0",
+  "video": "",
+  "url": "https://github.com/xbodwf/explorer-for-linux",
+  "authors": [
+    {
+      "name": "xbodwf",
+      "url": "https://github.com/xbodwf"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN"
+  ],
+  "intent": "practical"
+}


### PR DESCRIPTION
## 描述 / Description

- [x] 新增项目条目 (Add a new project entry)
- [ ] 修改项目数据 (Edit project data)
- [ ] 文档 / 配置变更 (Docs / config changes)
- [ ] 其他 (Other)

在 GUI Applications 组新增 [Explorer-for-Linux (xbodwf)](https://github.com/xbodwf/explorer-for-linux) —— 基于 Electron + Vue 与 WinUI 风格 Web 组件构建的 Win11 风格 Linux 文件管理器（包含部分来自 [WinUIonWeb](https://github.com/Furry-Xiyi/WinUIonWeb) 的代码，两者均为 GPL-3.0）。

注：与已有的 macOS-Terminal/Explorer-for-Linux 是两个不同项目，条目名已加以区分。

## 项目信息 (only for adding a project)

| 字段 / Field | 值 / Value |
| --- | --- |
| 项目名 / Project name | Explorer-for-Linux (xbodwf) |
| 仓库 / Repository | https://github.com/xbodwf/explorer-for-linux |
| 组 / Group | GUI Applications (`project-datas/2gui/`) |
| 许可证 / License | GPL-3.0 |

## 检查清单 / Checklist

- [x] 已运行 `python main.py generate` 重新生成 README（Ran generate to regenerate READMEs）
- [x] 已运行 `python main.py lint` 且无问题（Ran lint with no issues）
- [x] 所有语言 JSON 文件已同步（All language JSON files are in sync）

## 相关 Issue / Related issues

无 / None