### PR TITLE
feat: add PowerShell-For-Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Restores: Curating and organizing projects that recreate Windows.
 
 > Command-line tools that restore Windows terminal commands on Unix.
 
+### [PowerShell-For-Linux](https://github.com/SweetenedSuzuka/PowerShell-For-Linux) [Practical]
+
+Intro: A PowerShell-style shell interpreter for Linux, implemented in pure Go with zero third-party dependencies, supporting both the 5.X and 7.X command sets.
+
+Restores: The Windows PowerShell command-line experience: an object pipeline, 114 built-in cmdlets, and .ps1 scripting, letting you drive Linux with PowerShell-style commands.
+
+- License: MIT
+- Authors: [SweetenedSuzuka](https://github.com/SweetenedSuzuka)
+- Primary language: zh-CN
+- Supported languages: zh-CN / en-US
+- Intro video: (pending)
+
 ### [aptx](https://github.com/WenAnrong/aptx)
 
 Intro: An enhanced apt wrapper that recommends similar software after installing/removing packages.
@@ -405,4 +417,4 @@ Create the Pull Request; it merges once all Actions pass.
 [MIT](LICENSE) © 2026 windowix
 
 
-*Generated at: 2026-08-16 10:03 UTC*
+*Generated at: 2026-08-16 11:13 UTC*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,18 @@
 
 > 在 Unix 上还原 Windows 终端命令的命令行工具。
 
+### [PowerShell-For-Linux](https://github.com/SweetenedSuzuka/PowerShell-For-Linux) [实用]
+
+介绍：在 Linux 上运行的 PowerShell 风格命令解释器，纯 Go 实现、零第三方依赖，支持 5.X 与 7.X 两套命令格式。
+
+还原的部分：Windows PowerShell 的命令行体验：对象管道、114 个内置命令、.ps1 脚本，可用 PowerShell 风格命令直接操作 Linux 系统。
+
+- 许可证：MIT
+- 作者：[SweetenedSuzuka](https://github.com/SweetenedSuzuka)
+- 主要语言：zh-CN
+- 支持语言：zh-CN / en-US
+- 介绍视频：（待补充）
+
 ### [aptx](https://github.com/WenAnrong/aptx)
 
 介绍：apt 的增强封装，装 / 卸软件后自动推荐同类软件。
@@ -405,4 +417,4 @@ git push
 [MIT](LICENSE) © 2026 windowix
 
 
-*生成于: 2026-08-16 10:03 UTC*
+*生成于: 2026-08-16 11:13 UTC*

--- a/project-datas/1cli/PowerShell-For-Linux/en-US.json
+++ b/project-datas/1cli/PowerShell-For-Linux/en-US.json
@@ -1,0 +1,19 @@
+{
+  "name": "PowerShell-For-Linux",
+  "intro": "A PowerShell-style shell interpreter for Linux, implemented in pure Go with zero third-party dependencies, supporting both the 5.X and 7.X command sets.",
+  "restores": "The Windows PowerShell command-line experience: an object pipeline, 114 built-in cmdlets, and .ps1 scripting, letting you drive Linux with PowerShell-style commands.",
+  "license": "MIT",
+  "url": "https://github.com/SweetenedSuzuka/PowerShell-For-Linux",
+  "authors": [
+    {
+      "name": "SweetenedSuzuka",
+      "url": "https://github.com/SweetenedSuzuka"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "practical"
+}

--- a/project-datas/1cli/PowerShell-For-Linux/zh-CN.json
+++ b/project-datas/1cli/PowerShell-For-Linux/zh-CN.json
@@ -1,0 +1,19 @@
+{
+  "name": "PowerShell-For-Linux",
+  "intro": "在 Linux 上运行的 PowerShell 风格命令解释器，纯 Go 实现、零第三方依赖，支持 5.X 与 7.X 两套命令格式。",
+  "restores": "Windows PowerShell 的命令行体验：对象管道、114 个内置命令、.ps1 脚本，可用 PowerShell 风格命令直接操作 Linux 系统。",
+  "license": "MIT",
+  "url": "https://github.com/SweetenedSuzuka/PowerShell-For-Linux",
+  "authors": [
+    {
+      "name": "SweetenedSuzuka",
+      "url": "https://github.com/SweetenedSuzuka"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "practical"
+}


### PR DESCRIPTION
## 描述 / Description

增加了 `PowerShell-For-Linux`，项目将 PowerShell 的命令分为两类，其中一部分映射为对应的 Linux 命令，另一部分用 Go 实现，实现在 Linux 上使用 PowerShell 风格的命令控制系统。
可以使用 PowerShell 5.1 和 7 的两种命令风格，没有照搬官方的 PowerShell 7 的 Linux 版。
在一部分情况下确实可用，甚至可以执行 `ps1` 脚本，只要指令在项目内有实现即可。

The project has added `PowerShell-For-Linux`, which divides PowerShell commands into two categories: some are mapped to their corresponding Linux commands, while the rest are implemented in Go, enabling PowerShell-style command control on Linux systems.
It supports both PowerShell 5.1 and 7 command syntax styles, and is actually usable in certain scenarios — it can even execute `.ps1` scripts, as long as the commands used in the script are implemented within the project.

- [x] 新增项目条目 (Add a new project entry)
- [ ] 修改项目数据 (Edit project data)
- [ ] 文档 / 配置变更 (Docs / config changes)
- [ ] 其他 (Other)

## 项目信息 (only for adding a project)

| 字段 / Field | 值 / Value |
| --- | --- |
| 项目名 / Project name | PowerShell-For-Linux |
| 仓库 / Repository | https://github.com/SweetenedSuzuka/PowerShell-For-Linux |
| 组 / Group | CLI Tools |
| 许可证 / License | MIT |

## 检查清单 / Checklist

- [x] 已运行 `python main.py generate` 重新生成 README（Ran generate to regenerate READMEs）
- [x] 已运行 `python main.py lint` 且无问题（Ran lint with no issues）
- [x] 所有语言 JSON 文件已同步（All language JSON files are in sync）