### PR TITLE
feat(4lowlevel): add LSW (Linux Subsystem for Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,18 @@ Restores: PE / ELF file format structures (header, section table, program header
 - Supported languages: zh-CN
 - Intro video: https://www.bilibili.com/video/BV1p1gE6DEVF
 
+### [LSW](https://github.com/LING71671/lsw) [Practical]
+
+Intro: A production-grade Linux Subsystem for Windows written in pure Rust, providing 100% architectural and operational parity with Microsoft WSL. Official website & playground: https://lsw.int0.cc
+
+Restores: WSL1/WSL2/WSLg ecosystem on Linux (kernel-level PE execution, lswpath path translation, LSWENV cross-environment pipeline, ConPTY bridge, Smart Dual-Engine Auto-Routing).
+
+- License: MIT
+- Authors: [LING71671](https://github.com/LING71671)
+- Primary language: zh-CN
+- Supported languages: zh-CN / en-US
+- Intro video: (pending)
+
 ### [windows_update_in_linux](https://github.com/WenAnrong/windows_update_in_linux) [Prank]
 
 Intro: A prank program showing a fake Windows update screen: 50% chance of a real update+reboot, 50% chance of a blue screen.
@@ -525,4 +537,4 @@ Create the Pull Request; it merges once all Actions pass.
 [MIT](LICENSE) © 2026 windowix
 
 
-*Generated at: 2026-08-19 00:37 UTC*
+*Generated at: 2026-08-19 08:53 UTC*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -434,6 +434,18 @@
 - 支持语言：zh-CN
 - 介绍视频：https://www.bilibili.com/video/BV1p1gE6DEVF
 
+### [LSW](https://github.com/LING71671/lsw) [实用]
+
+介绍：专为 Linux 设计的高性能 Windows 子系统平台（Linux Subsystem for Windows），纯 Rust 实现，100% 架构级对齐微软 WSL。官方站点与在线终端 Playground：https://lsw.int0.cc
+
+还原的部分：WSL1/WSL2/WSLg 架构生态（PE 二进制内核拦截执行、lswpath 跨系统路径翻译、LSWENV 环境变量管道、ConPTY 双向桥接、双引擎自路由）。
+
+- 许可证：MIT
+- 作者：[LING71671](https://github.com/LING71671)
+- 主要语言：zh-CN
+- 支持语言：zh-CN / en-US
+- 介绍视频：（待补充）
+
 ### [windows_update_in_linux](https://github.com/WenAnrong/windows_update_in_linux) [整活]
 
 介绍：伪 Windows 更新界面的整活程序，每次运行 50% 真更新重启、50% 蓝屏。
@@ -525,4 +537,4 @@ git push
 [MIT](LICENSE) © 2026 windowix
 
 
-*生成于: 2026-08-19 00:37 UTC*
+*生成于: 2026-08-19 08:54 UTC*

--- a/project-datas/4lowlevel/lsw/en-US.json
+++ b/project-datas/4lowlevel/lsw/en-US.json
@@ -1,0 +1,19 @@
+{
+  "name": "LSW",
+  "intro": "A production-grade Linux Subsystem for Windows written in pure Rust, providing 100% architectural and operational parity with Microsoft WSL. Official website & playground: https://lsw.int0.cc",
+  "restores": "WSL1/WSL2/WSLg ecosystem on Linux (kernel-level PE execution, lswpath path translation, LSWENV cross-environment pipeline, ConPTY bridge, Smart Dual-Engine Auto-Routing).",
+  "license": "MIT",
+  "url": "https://github.com/LING71671/lsw",
+  "authors": [
+    {
+      "name": "LING71671",
+      "url": "https://github.com/LING71671"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "practical"
+}

--- a/project-datas/4lowlevel/lsw/zh-CN.json
+++ b/project-datas/4lowlevel/lsw/zh-CN.json
@@ -1,0 +1,19 @@
+{
+  "name": "LSW",
+  "intro": "专为 Linux 设计的高性能 Windows 子系统平台（Linux Subsystem for Windows），纯 Rust 实现，100% 架构级对齐微软 WSL。官方站点与在线终端 Playground：https://lsw.int0.cc",
+  "restores": "WSL1/WSL2/WSLg 架构生态（PE 二进制内核拦截执行、lswpath 跨系统路径翻译、LSWENV 环境变量管道、ConPTY 双向桥接、双引擎自路由）。",
+  "license": "MIT",
+  "url": "https://github.com/LING71671/lsw",
+  "authors": [
+    {
+      "name": "LING71671",
+      "url": "https://github.com/LING71671"
+    }
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "practical"
+}


### PR DESCRIPTION
### Summary
Add **LSW (Linux Subsystem for Windows)** to the \4lowlevel\ (Low-level / Reverse Engineering) category.

### Project Details
- **Name**: LSW
- **Category**: Low-level / Reverse Engineering (\4lowlevel\)
- **Intent**: \practical\
- **Repository**: https://github.com/LING71671/lsw
- **Official Website & Playground**: https://lsw.int0.cc
- **Description**: A production-grade subsystem platform written in pure Rust providing 100% architectural and operational parity with Microsoft WSL.

### Verification
- [x] \python main.py lint\ passed with 0 issues.
- [x] \python main.py generate\ executed and regenerated both \README.md\ and \README.zh-CN.md\.