### PR TITLE
feat:添加Linux-Activator项目 fix:修复Winget-for-Linux zh-CN描述的链接问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,18 @@ Restores: Windows Task Scheduler, Most of the UI and behavior
 
 > Projects that hook into system services: PAM modules, popups, global hotkeys.
 
+### [Linux-Activator](https://github.com/jihan-hanhan/Linux-Activator)
+
+Intro: Restored the 'Activate Windows' window (without watermark; installing activate-linux is recommended), and opened up the configuration file and interface to add more restrictions to 'unactivated Linux'.
+
+Restores: Restores the 'Activate Windows' window (without watermark)
+
+- License: MIT
+- Authors: [jihan_hanhan](https://github.com/jihan-hanhan)
+- Primary language: zh-CN
+- Supported languages: zh-CN / en-US
+- Intro video: https://www.bilibili.com/video/BV1cj8c6jE7f
+
 ### [adpop](https://github.com/MEKCCK/adpop) [Prank]
 
 Intro: A general-purpose ad-popup service rendered fully from scratch, callable by other software.
@@ -561,4 +573,4 @@ Create the Pull Request; it merges once all Actions pass.
 [MIT](LICENSE) © 2026 windowix
 
 
-*Generated at: 2026-08-22 00:38 UTC*
+*Generated at: 2026-08-22 09:24 UTC*

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,7 @@
 
 介绍：使用shell脚本将Winget搬运到Linux上
 
-还原的部分：App Installer(https://apps.microsoft.com/detail/9nblggh4nns1)中的Winget
+还原的部分：App Installer 中的Winget <https://apps.microsoft.com/detail/9nblggh4nns1>
 
 - 许可证：MIT
 - 作者：[jihan-hanhan](https://github.com/jihan-hanhan/)
@@ -382,6 +382,18 @@
 
 > 嵌入系统服务层的项目：PAM 模块、弹窗、全局热键。
 
+### [Linux-Activator](https://github.com/jihan-hanhan/Linux-Activator)
+
+介绍：还原了激活Windows窗口(不包含水印,建议安装activate-linux),开放了配置文件与接口,以为'未激活的Linux'添加更多限制
+
+还原的部分：激活Windows窗口(不包含水印)
+
+- 许可证：MIT
+- 作者：[jihan_hanhan](https://github.com/jihan-hanhan)
+- 主要语言：zh-CN
+- 支持语言：zh-CN / en-US
+- 介绍视频：https://www.bilibili.com/video/BV1cj8c6jE7f
+
 ### [adpop](https://github.com/MEKCCK/adpop) [整活]
 
 介绍：完全自绘渲染、供其他软件调用的通用广告弹窗服务。
@@ -561,4 +573,4 @@ git push
 [MIT](LICENSE) © 2026 windowix
 
 
-*生成于: 2026-08-22 00:38 UTC*
+*生成于: 2026-08-22 09:27 UTC*

--- a/project-datas/1cli/Winget-for-Linux/zh-CN.json
+++ b/project-datas/1cli/Winget-for-Linux/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "name": "Winget-for-Linux",
   "intro": "使用shell脚本将Winget搬运到Linux上",
-  "restores": "App Installer(https://apps.microsoft.com/detail/9nblggh4nns1)中的Winget",
+  "restores": "App Installer 中的Winget <https://apps.microsoft.com/detail/9nblggh4nns1>",
   "license": "MIT",
   "video": "https://www.bilibili.com/video/BV1S1b96GEXb",
   "url": "https://github.com/jihan-hanhan/Winget-for-Linux",

--- a/project-datas/3system/Linux-Activator/en-US.json
+++ b/project-datas/3system/Linux-Activator/en-US.json
@@ -1,0 +1,17 @@
+{
+  "name": "Linux-Activator",
+  "intro": "Restored the 'Activate Windows' window (without watermark; installing activate-linux is recommended), and opened up the configuration file and interface to add more restrictions to 'unactivated Linux'.",
+  "restores": "Restores the 'Activate Windows' window (without watermark)",
+  "license": "MIT",
+  "video": "https://www.bilibili.com/video/BV1cj8c6jE7f",
+  "url": "https://github.com/jihan-hanhan/Linux-Activator",
+  "authors": [
+    {"name":"jihan_hanhan","url":"https://github.com/jihan-hanhan"}
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "mixed"
+}

--- a/project-datas/3system/Linux-Activator/zh-CN.json
+++ b/project-datas/3system/Linux-Activator/zh-CN.json
@@ -1,0 +1,17 @@
+{
+  "name": "Linux-Activator",
+  "intro": "还原了激活Windows窗口(不包含水印,建议安装activate-linux),开放了配置文件与接口,以为'未激活的Linux'添加更多限制",
+  "restores": "激活Windows窗口(不包含水印)",
+  "license": "MIT",
+  "video": "https://www.bilibili.com/video/BV1cj8c6jE7f",
+  "url": "https://github.com/jihan-hanhan/Linux-Activator",
+  "authors": [
+    {"name":"jihan_hanhan","url":"https://github.com/jihan-hanhan"}
+  ],
+  "lang_primary": "zh-CN",
+  "lang_supported": [
+    "zh-CN",
+    "en-US"
+  ],
+  "intent": "mixed"
+}


### PR DESCRIPTION
## 描述 / Description

<!-- 简要说明这个 PR 做了什么：新增项目 / 修改数据 / 修复文档等。 -->
<!-- Briefly describe what this PR does: adding a project / editing data / fixing docs, etc. -->

- [x] 新增项目条目 (Add a new project entry)
- [x] 修改项目数据 (Edit project data)
- [ ] 文档 / 配置变更 (Docs / config changes)
- [ ] 其他 (Other)
1. 添加项目Linux-Activator
2. 由于本人之前添加的项目Winget-for-Linux zh-CN的文档中 还原部分这一栏 微软商店页面 链接未用<>,导致链接与后面的文字重合,已修复

## 项目信息 (only for adding a project)

| 字段 / Field | 值 / Value |
| --- | --- |
| 项目名 / Project name |Linux-Activator |
| 仓库 / Repository |https://github.com/jihan-hanhan/Linux-Activator |
| 组 / Group |system |
| 许可证 / License |MIT |

## 检查清单 / Checklist

- [x] 已运行 `python main.py generate` 重新生成 README（Ran generate to regenerate READMEs）
- [x] 已运行 `python main.py lint` 且无问题（Ran lint with no issues）
- [x] 所有语言 JSON 文件已同步（All language JSON files are in sync）

## 相关 Issue / Related issues

<!-- 如有，填写关联的 issue 编号。 -->
